### PR TITLE
improvement (#3):

### DIFF
--- a/bintrayconfig.gradle
+++ b/bintrayconfig.gradle
@@ -11,7 +11,7 @@ def BINTRAY_ORGINIZATION= "wengelef"
 def ISSUE_URL= "https://github.com/wengelef/validate/issues"
 def SITE_URL= "https://github.com/wengelef/validate"
 def VCS_URL= "https://github.com/wengelef/validate.git"
-def LIBRARY_VERSION_NAME="0.1.1"
+def LIBRARY_VERSION_NAME="0.1.2"
 
 group GROUP_ID
 version LIBRARY_VERSION_NAME

--- a/src/main/kotlin/dev/wengelef/validate/ValidationResult.kt
+++ b/src/main/kotlin/dev/wengelef/validate/ValidationResult.kt
@@ -10,4 +10,6 @@ sealed class ValidationResult<E, T> {
             is Invalid -> ifError(errors)
         }
     }
+
+    fun isValid() = this is Valid<E, T>
 }

--- a/src/main/kotlin/dev/wengelef/validate/validate.kt
+++ b/src/main/kotlin/dev/wengelef/validate/validate.kt
@@ -1,6 +1,6 @@
 package dev.wengelef.validate
 
-fun <E, T> validate(t: T, f: ValidationDSL<E, T>.() -> Unit): ValidationResult<E, T> {
+private fun <E, T> validate(t: T, f: ValidationDSL<E, T>.() -> Unit): ValidationResult<E, T> {
     return ValidationDSL<E, T>(t).apply(f).validate()
         .let { values ->
             val errors = values.filterIsInstance<Validation.Left<E, T>>()


### PR DESCRIPTION
* add `isValid()` method to ValidationResult
* make `validate(T, ValidationResult<E, T>.() -> Unit): ValidationResult<E, T>` private
* version 0.1.1 -> 0.1.2

resolves #3 